### PR TITLE
TG-1956: run as non root

### DIFF
--- a/lib-backend/Chart.yaml
+++ b/lib-backend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lib-backend
 description: Common templates for Youwol backends
 type: library
-version: 0.1.0
+version: 0.1.1

--- a/lib-backend/templates/_deployment.yaml.tpl
+++ b/lib-backend/templates/_deployment.yaml.tpl
@@ -28,6 +28,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          securityContext:
+            readOnlyRootFileSystem: true
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
           readinessProbe:
             httpGet:
               port: 8080


### PR DESCRIPTION
- 🔒️ Security context: run as 10000:10000
- 🔖 `libbackend` 0.1.1

TG-1956 #closed