### PR TITLE
TG-14: correct spelling of `readOnlyRootFileSystem`

### DIFF
--- a/lib-backend/Chart.yaml
+++ b/lib-backend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lib-backend
 description: Common templates for Youwol backends
 type: library
-version: 0.1.2
+version: 0.1.3

--- a/lib-backend/templates/_deployment.yaml.tpl
+++ b/lib-backend/templates/_deployment.yaml.tpl
@@ -29,7 +29,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           securityContext:
-            readOnlyRootFileSystem: true
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 10000
             runAsGroup: 10000


### PR DESCRIPTION
- 🐛 [lib-backend] typo on readOnlyRootFile[s,S]ystem
- 🔖 `lib-backend` 0.1.3

TG-14 #closed
